### PR TITLE
Bump release

### DIFF
--- a/buildrpm/kubernetes-container-image.spec
+++ b/buildrpm/kubernetes-container-image.spec
@@ -19,7 +19,7 @@
 
 Name:          kubernetes-container-image
 Version:       1.31.14
-Release:       2%{?dist}
+Release:       3%{?dist}
 Summary:       Container cluster management
 License:       ASL 2.0
 Group:         System/Management
@@ -83,6 +83,9 @@ done
 /usr/local/share/olcne/kubectl.tar
 
 %changelog
+* Mon Jun 29 2026 Daniel Krasinski <daniel.krasinski@oracle.com> - 1.31.14-3
+- Update latest OL8 base image
+
 * Thu Apr 23 2026 Daniel Krasinski <daniel.krasinski@oracle.com> - 1.31.14-2
 - Address CVE-2025-61726, CVE-2026-25679, CVE-2025-61728, CVE-2025-61729, CVE-2025-61730, CVE-2026-32280, CVE-2026-32281, CVE-2026-32283
 

--- a/buildrpm/kubernetes-container-image.spec
+++ b/buildrpm/kubernetes-container-image.spec
@@ -15,7 +15,7 @@
 %global patch          14
 %global image_registry container-registry.oracle.com/olcne
 
-%global image_version %{version}-1
+%global image_version %{version}-2
 
 Name:          kubernetes-container-image
 Version:       1.31.14

--- a/buildrpm/kubernetes.spec
+++ b/buildrpm/kubernetes.spec
@@ -17,7 +17,7 @@
 
 Name:          kubernetes
 Version:       1.31.14
-Release:       2%{?dist}
+Release:       3%{?dist}
 Summary:       Container cluster management
 License:       ASL 2.0
 Group:         System/Management
@@ -234,6 +234,9 @@ fi
 %systemd_postun_with_restart kubelet
 
 %changelog
+* Mon Jun 29 2026 Daniel Krasinski <daniel.krasinski@oracle.com> - 1.31.14-3
+- Update latest OL8 base image
+
 * Thu Apr 23 2026 Daniel Krasinski <daniel.krasinski@oracle.com> - 1.31.14-2
 - Address CVE-2025-61726, CVE-2026-25679, CVE-2025-61728, CVE-2025-61729, CVE-2025-61730, CVE-2026-32280, CVE-2026-32281, CVE-2026-32283
 

--- a/olm/jenkins/ci/Jenkinsfile
+++ b/olm/jenkins/ci/Jenkinsfile
@@ -4,7 +4,7 @@ import com.oracle.olcne.pipeline.BranchPattern
 
 String container_registry_namespace = "olcne";
 String kubernetes_version = "1.31.14";
-String kubernetes_image_tag = "v" + kubernetes_version + "-1";
+String kubernetes_image_tag = "v" + kubernetes_version + "-2";
 String registry = "container-registry.oracle.com/" + container_registry_namespace;
 
 olcnePipeline(


### PR DESCRIPTION
Bump releases to uptake latest OL8 base image.

## Container Images
- container-registry.oracle.com/olcne/kube-apiserver:v1.31.14-2
- container-registry.oracle.com/olcne/kube-controller-manager:v1.31.14-2
- container-registry.oracle.com/olcne/kube-proxy:v1.31.14-2
- container-registry.oracle.com/olcne/kube-scheduler:v1.31.14-2
- container-registry.oracle.com/olcne/kubectl:v1.31.14-2