### PR TITLE
bump release

### DIFF
--- a/buildrpm/kubernetes-container-image.spec
+++ b/buildrpm/kubernetes-container-image.spec
@@ -15,11 +15,11 @@
 %global patch          13
 %global image_registry container-registry.oracle.com/olcne
 
-%global image_version %{version}
+%global image_version %{version}-1
 
 Name:          kubernetes-container-image
 Version:       1.32.13
-Release:       1%{?dist}
+Release:       2%{?dist}
 Summary:       Container cluster management
 License:       ASL 2.0
 Group:         System/Management
@@ -83,5 +83,8 @@ done
 /usr/local/share/olcne/kubectl.tar
 
 %changelog
+* Mon Jun 29 2026 Daniel Krasinski <daniel.krasinski@oracle.com> - 1.32.13-2
+- Rebuild with latest OL8 base image
+
 * Sat Feb 28 2026 Oracle Cloud Native Environment Authors <noreply@oracle.com> - 1.32.13-1
 - Added Oracle specific build files for Kubernetes

--- a/buildrpm/kubernetes.spec
+++ b/buildrpm/kubernetes.spec
@@ -17,7 +17,7 @@
 
 Name:          kubernetes
 Version:       1.32.13
-Release:       1%{?dist}
+Release:       2%{?dist}
 Summary:       Container cluster management
 License:       ASL 2.0
 Group:         System/Management
@@ -234,5 +234,8 @@ fi
 %systemd_postun_with_restart kubelet
 
 %changelog
+* Mon Jun 29 2026 Daniel Krasinski <daniel.krasinski@oracle.com> - 1.32.13-2
+- Rebuild with latest OL8 base image
+
 * Sat Feb 28 2026 Oracle Cloud Native Environment Authors <noreply@oracle.com> - 1.32.13-1
 - Added Oracle specific build files for Kubernetes

--- a/olm/jenkins/ci/Jenkinsfile
+++ b/olm/jenkins/ci/Jenkinsfile
@@ -4,7 +4,7 @@ import com.oracle.olcne.pipeline.BranchPattern
 
 String container_registry_namespace = "olcne";
 String kubernetes_version = "1.32.13";
-String kubernetes_image_tag = "v" + kubernetes_version;
+String kubernetes_image_tag = "v" + kubernetes_version + "-1";
 String registry = "container-registry.oracle.com/" + container_registry_namespace;
 
 olcnePipeline(


### PR DESCRIPTION
Bump the release field so that the new OL8 base image is uptaken.

## Container Images
- container-registry.oracle.com/olcne/kube-apiserver:v1.32.13-1
- container-registry.oracle.com/olcne/kube-controller-manager:v1.32.13-1
- container-registry.oracle.com/olcne/kube-proxy:v1.32.13-1
- container-registry.oracle.com/olcne/kube-scheduler:v1.32.13-1
- container-registry.oracle.com/olcne/kubectl:v1.32.13-1